### PR TITLE
Show test name in results, not node name

### DIFF
--- a/src/Psecio/Parse/Output/Console.php
+++ b/src/Psecio/Parse/Output/Console.php
@@ -21,11 +21,13 @@ class Console extends \Psecio\Parse\Output
 
 			echo '#### Path: '.$file->getPath()." ########\n";
 			foreach ($matches as $match) {
+				$test = $match['test'];
+				$testName = str_replace('Psecio\\Parse\\Tests\\', '', get_class($test));
 				$node = $match['node']->getNode();
 				$attrs = $node->getAttributes();
 
 				echo '# '.$ct.' | '
-					.get_class($node)." | "
+					.$testName." | "
 					.trim(implode("\n",$file->getLines($attrs['startLine'])))
 					."\n";
 


### PR DESCRIPTION
This seems to be more useful; although maybe for debugging purposes the node name would be useful as well.

I realize the current output is just a placeholder, but it might as well be a useful placeholder :)
