### PR TITLE
Enable multiple paths in scanner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require":{
-	"nikic/php-parser": "~1.0",
+        "php": ">=5.4",
+        "nikic/php-parser": "~1.0",
         "symfony/console": "~2.5",
         "monolog/monolog": "~1.11"
     },


### PR DESCRIPTION
This pr enable using multiple paths in `Scanner`. It also sets the current working directory as default in `ScanCommand`, making the path argument optional.

It also does some updates making `Scanner` more testable. General housekeeping. And specifies the required php version in `composer.json` (fix #19).