### PR TITLE
Enable scan paths to be filenames

### DIFF
--- a/src/Psecio/Parse/FileIterator.php
+++ b/src/Psecio/Parse/FileIterator.php
@@ -9,16 +9,17 @@ use RecursiveDirectoryIterator;
 use FilesystemIterator;
 use ArrayIterator;
 use SplFileInfo;
+use RuntimeException;
 
 /**
- * Responsible for locating and iterating over File objects
+ * Responsible for iterating over filesystem paths
  */
 class FileIterator implements IteratorAggregate, Countable
 {
     /**
      * @var File[] Array of File objects using paths as keys
      */
-    private $files;
+    private $files = [];
 
     /**
      * Append paths to iterator
@@ -30,9 +31,9 @@ class FileIterator implements IteratorAggregate, Countable
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $this->appendDir($path);
-            } elseif (is_file($path)) {
-                $this->appendFile($path);
+                continue;
             }
+            $this->appendFile($path);
         }
     }
 
@@ -60,10 +61,16 @@ class FileIterator implements IteratorAggregate, Countable
      *
      * @param  string $filename
      * @return null
+     * @throws RuntimeException If filename does not exist
      */
     public function appendFile($filename)
     {
         $splFileInfo = new SplFileInfo($filename);
+
+        if (!$splFileInfo->isReadable()) {
+            throw new RuntimeException("Failed to open $filename: No such file or directory");
+        }
+
         $this->files[$splFileInfo->getRealPath()] = new File($splFileInfo);
     }
 

--- a/src/Psecio/Parse/FileIterator.php
+++ b/src/Psecio/Parse/FileIterator.php
@@ -8,6 +8,7 @@ use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use FilesystemIterator;
 use ArrayIterator;
+use SplFileInfo;
 
 /**
  * Responsible for locating and iterating over File objects
@@ -27,7 +28,11 @@ class FileIterator implements IteratorAggregate, Countable
     public function __construct(array $paths = array())
     {
         foreach ($paths as $path) {
-            $this->appendDir($path);
+            if (is_dir($path)) {
+                $this->appendDir($path);
+            } elseif (is_file($path)) {
+                $this->appendFile($path);
+            }
         }
     }
 
@@ -35,7 +40,7 @@ class FileIterator implements IteratorAggregate, Countable
      * Recursicely append files in directory
      *
      * @param  string $directory Pathname of directory
-     * @return void
+     * @return null
      */
     public function appendDir($directory)
     {
@@ -46,8 +51,20 @@ class FileIterator implements IteratorAggregate, Countable
             )
         );
         foreach ($iterator as $splFileInfo) {
-            $this->files[$splFileInfo->getPathname()] = new File($splFileInfo);
+            $this->files[$splFileInfo->getRealPath()] = new File($splFileInfo);
         }
+    }
+
+    /**
+     * Append file to iterator
+     *
+     * @param  string $filename
+     * @return null
+     */
+    public function appendFile($filename)
+    {
+        $splFileInfo = new SplFileInfo($filename);
+        $this->files[$splFileInfo->getRealPath()] = new File($splFileInfo);
     }
 
     /**

--- a/tests/Psecio/Parse/FileIteratorTest.php
+++ b/tests/Psecio/Parse/FileIteratorTest.php
@@ -22,6 +22,17 @@ class FileIteratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFilenamePath()
+    {
+        $this->assertTrue(
+            array_key_exists(
+                __DIR__.'/FileIteratorTest.php',
+                iterator_to_array(new FileIterator([__FILE__]))
+            ),
+            __FILE__ . ' should be found in iterator'
+        );
+    }
+
     public function testCountable()
     {
         $this->assertTrue(

--- a/tests/Psecio/Parse/FileIteratorTest.php
+++ b/tests/Psecio/Parse/FileIteratorTest.php
@@ -4,7 +4,7 @@ namespace Psecio\Parse;
 
 class FileIteratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIterator()
+    public function testDirectoryPath()
     {
         // Create array of files in Subscriber and Tests subdirs
         $files = iterator_to_array(
@@ -31,6 +31,12 @@ class FileIteratorTest extends \PHPUnit_Framework_TestCase
             ),
             __FILE__ . ' should be found in iterator'
         );
+    }
+
+    public function testExceptionOnInvalidPath()
+    {
+        $this->setExpectedException('RuntimeException');
+        new FileIterator(['this/really/does/not/exist/at/all']);
     }
 
     public function testCountable()


### PR DESCRIPTION
A simple pr that makes it possible to scan individual files

```
bin/parse scan src/Psecio/Parse/Tests/TestLogicalOperatorsFound.php
```