### PR TITLE
Set the exit status of a scan to 1 when issues are found

### DIFF
--- a/src/Psecio/Parse/Command/ScanCommand.php
+++ b/src/Psecio/Parse/Command/ScanCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Psecio\Parse\Subscriber\ExitCodeCatcher;
 use Psecio\Parse\Subscriber\ConsoleStandard;
 use Psecio\Parse\Subscriber\ConsoleVerbose;
 use Psecio\Parse\Subscriber\ConsoleDebug;
@@ -75,6 +76,8 @@ class ScanCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dispatcher = new EventDispatcher;
+        $exitCode = new ExitCodeCatcher;
+        $dispatcher->addSubscriber($exitCode);
 
         switch (strtolower($input->getOption('format'))) {
             case 'txt':
@@ -104,5 +107,7 @@ class ScanCommand extends Command
         $scanner->scan(
             new FileIterator($input->getArgument('path'))
         );
+
+        return $exitCode->getExitCode();
     }
 }

--- a/src/Psecio/Parse/Subscriber/ExitCodeCatcher.php
+++ b/src/Psecio/Parse/Subscriber/ExitCodeCatcher.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Psecio\Parse\Subscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Psecio\Parse\Event\Events;
+
+/**
+ * Capture the exit status code of a scan
+ */
+class ExitCodeCatcher implements EventSubscriberInterface, Events
+{
+    /**
+     * @var integer Suggested exit code
+     */
+    private $exitCode = 0;
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::FILE_ISSUE => 'onFileIssue',
+            self::FILE_ERROR => 'onFileError'
+        ];
+    }
+
+    /**
+     * Get suggested exit code
+     *
+     * @return integer
+     */
+    public function getExitCode()
+    {
+        return $this->exitCode;
+    }
+
+    /**
+     * Set exit code 1 on file issue
+     *
+     * @return null
+     */
+    public function onFileIssue()
+    {
+        $this->exitCode = 1;
+    }
+
+    /**
+     * Set exit code 1 on file error
+     *
+     * @return null
+     */
+    public function onFileError()
+    {
+        $this->exitCode = 1;
+    }
+}

--- a/tests/Psecio/Parse/Subscriber/ExitCodeCatcherTest.php
+++ b/tests/Psecio/Parse/Subscriber/ExitCodeCatcherTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Psecio\Parse\Subscriber;
+
+class ExitCodeCatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSuccessCode()
+    {
+        $this->assertSame(
+            0,
+            (new ExitCodeCatcher)->getExitCode()
+        );
+    }
+
+    public function testErrorcodeOnIssue()
+    {
+        $exitCode = new ExitCodeCatcher;
+        $exitCode->onFileIssue();
+        $this->assertSame(1, $exitCode->getExitCode());
+    }
+
+    public function testErrorcodeOnError()
+    {
+        $exitCode = new ExitCodeCatcher;
+        $exitCode->onFileError();
+        $this->assertSame(1, $exitCode->getExitCode());
+    }
+
+    public function testSubscription()
+    {
+        $this->assertInternalType(
+            'array',
+            ExitCodeCatcher::getSubscribedEvents()
+        );
+    }
+}


### PR DESCRIPTION
This pr makes scan return exit code 0 on success and 1 if errors or issues are found.

Suitable when using parse in a ci environment, as it makes it possible to fail a build when security issues are found.