### PR TITLE
Simplify executable

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 date_default_timezone_set('UTC');
 
 set_time_limit(0);
@@ -7,25 +8,10 @@ set_time_limit(0);
 (@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Psecio\Parse\Command\ScanCommand;
+use Psecio\Parse\Command\ListTestsCommand;
 
-$output = new ConsoleOutput();
-$app = new Application('Parse Scan', '1.0');
-$app->addCommands(array(
-	new \Psecio\Parse\Command\ScanCommand(),
-	new \Psecio\Parse\Command\ListTestsCommand()
-));
-$app->setCatchExceptions(false);
-
-try {
-    $app->run();
-} catch (\Exception $e) {
-    $indent = str_repeat(' ', 3);
-    $output->writeLn(
-        $indent."<fg=white;bg=red;options=bold>ERROR:".str_repeat(' ', 20)."</fg=white;bg=red;options=bold>\n"
-        .$indent."<fg=red>[".$e->getCode()."] ".$e->getMessage()."</fg=red>"
-    );
-    exit(1);
-}
-
-?>
+$app = new Application('Parse Scan', 'dev');
+$app->add(new ScanCommand);
+$app->add(new ListTestsCommand);
+$app->run();


### PR DESCRIPTION
After reviewing the output system I think the custom exception handling in `bin/parse` is no longer necessary. The standard exception handler displays a little more information on how to use the command in question.

Also I changed the version number from `1.0` to `dev`, as the tool is not stable yet..