### PR TITLE
Make the format option require a value when used

### DIFF
--- a/src/Psecio/Parse/Command/ScanCommand.php
+++ b/src/Psecio/Parse/Command/ScanCommand.php
@@ -42,7 +42,7 @@ class ScanCommand extends Command
             ->addOption(
                 'format',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Output format (txt or xml).',
                 'txt'
             )


### PR DESCRIPTION
When commenting on pr #30 I realised the `format` option was defined as optionally receiving a value. This of course is incorrect, if the format option is used a value should be required.