### PR TITLE
Fix unittests with error_reporting = E_ALL

### DIFF
--- a/src/Psecio/Parse/Subscriber/ConsoleStandard.php
+++ b/src/Psecio/Parse/Subscriber/ConsoleStandard.php
@@ -5,6 +5,9 @@ namespace Psecio\Parse\Subscriber;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Psecio\Parse\Event\Events;
+use Psecio\Parse\Event\FileEvent;
+use Psecio\Parse\Event\IssueEvent;
+use Psecio\Parse\Event\MessageEvent;
 
 /**
  * Standard console event subscriber
@@ -94,9 +97,10 @@ class ConsoleStandard implements EventSubscriberInterface, Events
     /**
      * Set status to valid on file open
      *
+     * @param  FileEvent $event
      * @return void
      */
-    public function onFileOpen()
+    public function onFileOpen(FileEvent $event)
     {
         $this->fileCount++;
         $this->status = '.';
@@ -118,9 +122,10 @@ class ConsoleStandard implements EventSubscriberInterface, Events
     /**
      * Set file status to I on file issue
      *
+     * @param  IssueEvent $event
      * @return void
      */
-    public function onFileIssue()
+    public function onFileIssue(IssueEvent $event)
     {
         $this->status = '<error>I</error>';
     }
@@ -128,9 +133,10 @@ class ConsoleStandard implements EventSubscriberInterface, Events
     /**
      * Set file status to E on file error
      *
+     * @param  MessageEvent $event
      * @return void
      */
-    public function onFileError()
+    public function onFileError(MessageEvent $event)
     {
         $this->status = '<error>E</error>';
     }
@@ -138,9 +144,10 @@ class ConsoleStandard implements EventSubscriberInterface, Events
     /**
      * Ignore debug events
      *
+     * @param  MessageEvent $event
      * @return void
      */
-    public function onDebug()
+    public function onDebug(MessageEvent $event)
     {
     }
 

--- a/tests/Psecio/Parse/Subscriber/ConsoleStandardTest.php
+++ b/tests/Psecio/Parse/Subscriber/ConsoleStandardTest.php
@@ -25,22 +25,22 @@ class ConsoleStandardTest extends \PHPUnit_Framework_TestCase
         $console->onScanStart();
 
         // Writes a dot as a file is scanned
-        $console->onFileOpen();
+        $console->onFileOpen(m::mock('\Psecio\Parse\Event\FileEvent'));
         $console->onFileClose();
 
         // Writes an E as an error occurs
         // Also triggers a new line as the line witdth is set to 2
-        $console->onFileOpen();
-        $console->onFileError();
+        $console->onFileOpen(m::mock('\Psecio\Parse\Event\FileEvent'));
+        $console->onFileError(m::mock('\Psecio\Parse\Event\MessageEvent'));
         $console->onFileClose();
 
         // Writes an I as an issue occurs
-        $console->onFileOpen();
-        $console->onFileIssue();
+        $console->onFileOpen(m::mock('\Psecio\Parse\Event\FileEvent'));
+        $console->onFileIssue(m::mock('\Psecio\Parse\Event\IssueEvent'));
         $console->onFileClose();
 
         // Writes nothing
-        $console->onDebug();
+        $console->onDebug(m::mock('\Psecio\Parse\Event\MessageEvent'));
 
         // Writes two new lines
         $console->onScanComplete();

--- a/tests/Psecio/Parse/Subscriber/ConsoleVerboseTest.php
+++ b/tests/Psecio/Parse/Subscriber/ConsoleVerboseTest.php
@@ -54,7 +54,7 @@ class ConsoleVerboseTest extends \PHPUnit_Framework_TestCase
         $console->onFileClose();
 
         // Writes nothing
-        $console->onDebug();
+        $console->onDebug(m::mock('\Psecio\Parse\Event\MessageEvent'));
 
         // Writes extra new line
         $console->onScanComplete();


### PR DESCRIPTION
As it turns out i didn't have strict error reporting on my dev machine. Oops. Now all unit test pass for php versions 5.4, 5.5 and 5.6, and HHVM.