### PR TITLE
Relax rules for TestExitOrDie

### DIFF
--- a/src/Tests/TestExitOrDie.php
+++ b/src/Tests/TestExitOrDie.php
@@ -4,6 +4,7 @@ namespace Psecio\Parse\Tests;
 
 use Psecio\Parse\TestInterface;
 use PhpParser\Node;
+use PhpParser\Node\Scalar\LNumber;
 use Psecio\Parse\File;
 
 /**
@@ -15,11 +16,13 @@ class TestExitOrDie implements TestInterface
 
     public function getDescription()
     {
-        return 'Avoid the use of `exit` or `die` (could lead to injection issues (direct output)';
+        return 'Avoid the use of `exit` or `die` with strings as it could lead to injection issues (direct output)';
     }
 
     public function evaluate(Node $node, File $file)
     {
-        return !$this->isExpression($node, 'Exit');
+        return (!$this->isExpression($node, 'Exit') ||
+                is_null($node->expr) ||
+                ($node->expr instanceof LNumber));
     }
 }

--- a/tests/Tests/TestExitOrDieParseTest.php
+++ b/tests/Tests/TestExitOrDieParseTest.php
@@ -9,11 +9,11 @@ class TestExitOrDieParseTest extends ParseTest
     public function parseSampleProvider()
     {
         return [
-            /* // Bare exit should be ok. */
+            // Bare exit should be ok.
             ['exit;', true],
             ['die;', true],
 
-            /* // Exit with error code should be ok. */
+            // Exit with error code should be ok.
             ['exit(1);', true],
             ['die(1);', true],
 

--- a/tests/Tests/TestExitOrDieParseTest.php
+++ b/tests/Tests/TestExitOrDieParseTest.php
@@ -9,9 +9,24 @@ class TestExitOrDieParseTest extends ParseTest
     public function parseSampleProvider()
     {
         return [
+            /* // Bare exit should be ok. */
+            ['exit;', true],
+            ['die;', true],
+
+            /* // Exit with error code should be ok. */
+            ['exit(1);', true],
+            ['die(1);', true],
+
             // Shouldn't exit with a string
             ['exit("message");', false],
             ['die("message");', false],
+
+            // Shouldn't exit with a variable
+            ['exit($e);', false],
+            ['die($e);', false],
+
+            // Something else
+            ['exitOrNot("message");', true],
             ];
     }
 


### PR DESCRIPTION
I believe that `TestExitOrDie` can be relaxed.

* A bare `exit;` won't do any output. Should be safe.
* Exiting with an integer (`exit(1)`) is a completely valid way to exit, especially in CLI situations. And since it doesn't make any output, it should be safe.