### PR TITLE
Add simple test for getDescription

### DIFF
--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -66,6 +66,14 @@ abstract class ParseTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testDescription()
+    {
+        $this->assertInternalType(
+            'string',
+            $this->buildTest()->getDescription()
+        );
+    }
+
     /**
      * Assert that running $test against $code results in $expected
      *


### PR DESCRIPTION
Simple test to check the behaviour of `getDescription` in all tests. (We are starting to get great test coverage!)