### PR TITLE
Refactor file and add fetchNode

### DIFF
--- a/src/FileIterator.php
+++ b/src/FileIterator.php
@@ -9,7 +9,6 @@ use RecursiveDirectoryIterator;
 use FilesystemIterator;
 use ArrayIterator;
 use SplFileInfo;
-use RuntimeException;
 
 /**
  * Responsible for iterating over filesystem paths
@@ -61,16 +60,10 @@ class FileIterator implements IteratorAggregate, Countable
      *
      * @param  string $filename
      * @return null
-     * @throws RuntimeException If filename does not exist
      */
     public function appendFile($filename)
     {
         $splFileInfo = new SplFileInfo($filename);
-
-        if (!$splFileInfo->isReadable()) {
-            throw new RuntimeException("Failed to open $filename: No such file or directory");
-        }
-
         $this->files[$splFileInfo->getRealPath()] = new File($splFileInfo);
     }
 

--- a/src/Subscriber/ConsoleReport.php
+++ b/src/Subscriber/ConsoleReport.php
@@ -183,14 +183,13 @@ class ConsoleReport implements EventSubscriberInterface, Events
         );
 
         foreach ($this->issues as $index => $issueEvent) {
-            $attrs = $issueEvent->getNode()->getAttributes();
             $str .= sprintf(
                 "\n%d) %s:%d\n%s\n> %s\n",
                 $index + 1,
                 $issueEvent->getFile()->getPath(),
-                $attrs['startLine'],
+                $issueEvent->getNode()->getLine(),
                 $issueEvent->getTest()->getDescription(),
-                trim(implode("\n> ", $issueEvent->getFile()->getLines($attrs['startLine'])))
+                implode("\n> ", $issueEvent->getFile()->fetchNode($issueEvent->getNode()))
             );
         }
 

--- a/src/Subscriber/ConsoleVerbose.php
+++ b/src/Subscriber/ConsoleVerbose.php
@@ -49,11 +49,10 @@ class ConsoleVerbose extends ConsoleStandard
      */
     public function onFileIssue(IssueEvent $event)
     {
-        $attrs = $event->getNode()->getAttributes();
         $this->write(
             "<error>[ISSUE] [%s] On line %d in %s</error>\n",
             $event->getTest()->getName(),
-            $attrs['startLine'],
+            $event->getNode()->getLine(),
             $event->getFile()->getPath()
         );
     }

--- a/src/Subscriber/Xml.php
+++ b/src/Subscriber/Xml.php
@@ -86,14 +86,13 @@ class Xml implements EventSubscriberInterface, Events
      */
     public function onFileIssue(IssueEvent $event)
     {
-        $attrs = $event->getNode()->getAttributes();
         $this->xmlWriter->startElement('issue');
         $this->xmlWriter->writeElement('type', $event->getTest()->getName());
         $this->xmlWriter->writeElement('description', $event->getTest()->getDescription());
         $this->xmlWriter->writeElement('file', $event->getFile()->getPath());
-        $this->xmlWriter->writeElement('line', $attrs['startLine']);
+        $this->xmlWriter->writeElement('line', $event->getNode()->getLine());
         $this->xmlWriter->startElement('source');
-        $this->xmlWriter->writeCData(trim(implode("\n", $event->getFile()->getLines($attrs['startLine']))));
+        $this->xmlWriter->writeCData(implode("\n", $event->getFile()->fetchNode($event->getNode())));
         $this->xmlWriter->endElement();
         $this->xmlWriter->endElement();
     }

--- a/tests/FileIteratorTest.php
+++ b/tests/FileIteratorTest.php
@@ -4,20 +4,26 @@ namespace Psecio\Parse;
 
 class FileIteratorTest extends \PHPUnit_Framework_TestCase
 {
-    protected static $dirs = ['testFiles/FileIteratorTest1',
-                              'testFiles/FileIteratorTest2'];
+    protected static $dirs = [
+        'testFiles/FileIteratorTest1',
+        'testFiles/FileIteratorTest2'
+    ];
 
     protected $fullDirs;
 
-    protected static $expectedFiles = [ [ 'README.md', 'test-2.md', 'test-3.md', 'test-4.md' ],
-                                        [ 'README.md', 'test-1.md' ], ];
+    protected static $expectedFiles = [
+        [ 'README.md', 'test-2.md', 'test-3.md', 'test-4.md' ],
+        [ 'README.md', 'test-1.md' ]
+    ];
 
     public function setUp()
     {
         $this->fullDirs = array_map(
-            function($d) { return __DIR__ . DIRECTORY_SEPARATOR . $d; },
+            function($d) {
+                return __DIR__ . DIRECTORY_SEPARATOR . $d;
+            },
             self::$dirs
-            );
+        );
     }
 
     public function testDirectoryPath()
@@ -28,9 +34,11 @@ class FileIteratorTest extends \PHPUnit_Framework_TestCase
         foreach (self::$dirs as $k => $dirName) {
             $fullPath = $this->fullDirs[$k] . DIRECTORY_SEPARATOR;
             foreach (self::$expectedFiles[$k] as $fileName) {
-                $this->assertArrayHasKey($fullPath . $fileName,
-                                         $files,
-                                         "$fileName should be found in $dirName subdirectory");
+                $this->assertArrayHasKey(
+                    $fullPath . $fileName,
+                    $files,
+                    "$fileName should be found in $dirName subdirectory"
+                );
             }
         }
     }
@@ -46,20 +54,15 @@ class FileIteratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testExceptionOnInvalidPath()
-    {
-        $this->setExpectedException('RuntimeException');
-        new FileIterator(['this/really/does/not/exist/at/all']);
-    }
-
     public function testCountable()
     {
         $expected = count(self::$expectedFiles[0]);
         $full = $this->fullDirs[0];
         $sub = self::$dirs[0];
-        $this->assertEquals($expected,
-                            count(new FileIterator([$full])),
-                            "The $sub subdir should contain $expected files"
+        $this->assertEquals(
+            $expected,
+            count(new FileIterator([$full])),
+            "The $sub subdir should contain $expected files"
         );
     }
 }

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -59,6 +59,12 @@ class FileTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame(
+            ["line 3"],
+            $file->fetchLines(3, 3),
+            'Specifying the same line twice should grab that line'
+        );
+
+        $this->assertSame(
             ["line 1", "line 2"],
             $file->fetchNode(
                 m::mock('PhpParser\Node')

--- a/tests/Subscriber/ConsoleReportTest.php
+++ b/tests/Subscriber/ConsoleReportTest.php
@@ -58,10 +58,12 @@ error description
 
         $file = m::mock('\Psecio\Parse\File');
         $file->shouldReceive('getPath')->once()->andReturn('/issue/path');
-        $file->shouldReceive('getLines')->once()->with('1')->andReturn(['php source']);
+        $file->shouldReceive('fetchNode')->once()->andReturn(['php source']);
 
         $issueEvent = m::mock('\Psecio\Parse\Event\IssueEvent');
-        $issueEvent->shouldReceive('getNode->getAttributes')->once()->andReturn(['startLine' => '1']);
+        $issueEvent->shouldReceive('getNode')->atLeast(1)->andReturn(
+            m::mock('PhpParser\Node')->shouldReceive('getLine')->atLeast(1)->andReturn(1)->mock()
+        );
         $issueEvent->shouldReceive('getTest->getDescription')->once()->andReturn('issue description');
         $issueEvent->shouldReceive('getFile')->zeroOrMoreTimes()->andReturn($file);
 

--- a/tests/Subscriber/ConsoleVerboseTest.php
+++ b/tests/Subscriber/ConsoleVerboseTest.php
@@ -30,7 +30,7 @@ class ConsoleVerboseTest extends \PHPUnit_Framework_TestCase
 
         // Data for [ISSUE] line
         $issueEvent = m::mock('\Psecio\Parse\Event\IssueEvent');
-        $issueEvent->shouldReceive('getNode->getAttributes')->andReturn(['startLine' => '1']);
+        $issueEvent->shouldReceive('getNode->getLine')->andReturn(1);
         $issueEvent->shouldReceive('getTest->getName')->andReturn('Test');
         $issueEvent->shouldReceive('getFile->getPath')->andReturn('path');
 

--- a/tests/Subscriber/XmlTest.php
+++ b/tests/Subscriber/XmlTest.php
@@ -43,10 +43,12 @@ class XmlTest extends \PHPUnit_Framework_TestCase
 
         $file = m::mock('\Psecio\Parse\File');
         $file->shouldReceive('getPath')->once()->andReturn('/issue/path');
-        $file->shouldReceive('getLines')->once()->with('1')->andReturn(['php source']);
+        $file->shouldReceive('fetchNode')->once()->andReturn(['php source']);
 
         $issueEvent = m::mock('\Psecio\Parse\Event\IssueEvent');
-        $issueEvent->shouldReceive('getNode->getAttributes')->once()->andReturn(['startLine' => '1']);
+        $issueEvent->shouldReceive('getNode')->atLeast(1)->andReturn(
+            m::mock('PhpParser\Node')->shouldReceive('getLine')->atLeast(1)->andReturn(1)->mock()
+        );
         $issueEvent->shouldReceive('getTest->getName')->once()->andReturn('TestName');
         $issueEvent->shouldReceive('getTest->getDescription')->once()->andReturn('issue description');
         $issueEvent->shouldReceive('getFile')->zeroOrMoreTimes()->andReturn($file);


### PR DESCRIPTION
This adds `fetchNode` to `File` so that nodes that span multiple lines will display correctly. It also renames `getLines` to `fetchLines` and fixes a few errors:

* files with other line endings than `\n` are now supported using `file()` instead of `file_get_contents()`
* makes `fetchLines` work when start and end lines are the same (didn't work before)
* moved the file-not-found exception from `FileIterator` to `File` as `RecursiveDirectoryIterator` happily iterates over files that are not accesable.

As I was touching `FileIteratorTest` I also made it conform to the [psr-2 coding style standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).