### PR TITLE
Fix case sensitive file name for travis builds

### DIFF
--- a/src/Tests/TestDisableDisplayErrors.php
+++ b/src/Tests/TestDisableDisplayErrors.php
@@ -12,7 +12,7 @@ use PhpParser\Node\Arg;
  */
 class TestDisableDisplayErrors implements TestInterface
 {
-    use Helper\NameTrait, Helper\IsFunctionTrait, Helper\isBoolLiteralTrait;
+    use Helper\NameTrait, Helper\IsFunctionTrait, Helper\IsBoolLiteralTrait;
 
     /**
      * @var array List of allowed display_errors settings


### PR DESCRIPTION
Maybe you have notived that we have had some travis inconsistencies. Builds have been failing, but if restarted passing. Not very conforting at all.

I looked into it, and it turns out that some travis builders use case sensitive file system lookups, and some does not. Anyway I made a mistake in `TestDisableDisplayErrors` when using the wrong case for `IsBoolLiteralTrait`. With this fix builds should pass without problems..