### PR TITLE
Throw exceptions when unknown rules are white- or blacklisted

### DIFF
--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -2,12 +2,12 @@
 
 namespace Psecio\Parse\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Psecio\Parse\File;
 
 /**
- * Event containing a message
+ * Event containing a File and a message
  */
-class MessageEvent extends Event
+class ErrorEvent extends FileEvent
 {
     /**
      * @var string Message
@@ -18,9 +18,11 @@ class MessageEvent extends Event
      * Set File and message
      *
      * @param string $message
+     * @param File $file
      */
-    public function __construct($message)
+    public function __construct($message, File $file)
     {
+        parent::__construct($file);
         $this->message = $message;
     }
 

--- a/src/Event/Events.php
+++ b/src/Event/Events.php
@@ -39,7 +39,7 @@ interface Events
     /**
      * A scan.file_error event is fired when a file error is encountered
      *
-     * The event listener receives an \Psecio\Parse\Event\MessageEvent instance.
+     * The event listener receives an \Psecio\Parse\Event\ErrorEvent instance.
      */
     const FILE_ERROR = 'scan.file_error';
 

--- a/src/FileIterator.php
+++ b/src/FileIterator.php
@@ -59,7 +59,7 @@ class FileIterator implements IteratorAggregate, Countable
     /**
      * Add list of file extensions to include when scanning dirs
      *
-     * @param  array $extensions
+     * @param  string[] $extensions
      * @return void
      */
     public function addExtensions(array $extensions)

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -84,7 +84,7 @@ class Scanner implements Event\Events
             if ($file->isPathMatch('/\.phps$/i')) {
                 $this->dispatcher->dispatch(
                     self::FILE_ERROR,
-                    new Event\MessageEvent('You have a .phps file - REMOVE NOW', $file)
+                    new Event\ErrorEvent('You have a .phps file - REMOVE NOW', $file)
                 );
             }
 
@@ -94,7 +94,7 @@ class Scanner implements Event\Events
             } catch (\PhpParser\Error $e) {
                 $this->dispatcher->dispatch(
                     self::FILE_ERROR,
-                    new Event\MessageEvent($e->getMessage(), $file)
+                    new Event\ErrorEvent($e->getMessage(), $file)
                 );
             }
 

--- a/src/Subscriber/ConsoleDots.php
+++ b/src/Subscriber/ConsoleDots.php
@@ -4,7 +4,7 @@ namespace Psecio\Parse\Subscriber;
 
 use Psecio\Parse\Event\FileEvent;
 use Psecio\Parse\Event\IssueEvent;
-use Psecio\Parse\Event\MessageEvent;
+use Psecio\Parse\Event\ErrorEvent;
 
 /**
  * Display phpunit style dots to visualize scan progression
@@ -88,10 +88,10 @@ class ConsoleDots extends Subscriber
     /**
      * Set file status to E on file error
      *
-     * @param  MessageEvent $event
+     * @param  ErrorEvent $event
      * @return void
      */
-    public function onFileError(MessageEvent $event)
+    public function onFileError(ErrorEvent $event)
     {
         $this->status = '<error>E</error>';
     }

--- a/src/Subscriber/ConsoleLines.php
+++ b/src/Subscriber/ConsoleLines.php
@@ -4,7 +4,7 @@ namespace Psecio\Parse\Subscriber;
 
 use Psecio\Parse\Event\FileEvent;
 use Psecio\Parse\Event\IssueEvent;
-use Psecio\Parse\Event\MessageEvent;
+use Psecio\Parse\Event\ErrorEvent;
 
 /**
  * Display descriptive lines to visualize scan progression
@@ -43,10 +43,10 @@ class ConsoleLines extends Subscriber
     /**
      * Write error as one line
      *
-     * @param  MessageEvent $event
+     * @param  ErrorEvent $event
      * @return void
      */
-    public function onFileError(MessageEvent $event)
+    public function onFileError(ErrorEvent $event)
     {
         $this->write(
             "<error>[ERROR] %s in %s</error>\n",

--- a/src/Subscriber/ConsoleReport.php
+++ b/src/Subscriber/ConsoleReport.php
@@ -4,7 +4,7 @@ namespace Psecio\Parse\Subscriber;
 
 use Psecio\Parse\Event\FileEvent;
 use Psecio\Parse\Event\IssueEvent;
-use Psecio\Parse\Event\MessageEvent;
+use Psecio\Parse\Event\ErrorEvent;
 
 /**
  * Print report at scan complete
@@ -75,10 +75,10 @@ class ConsoleReport extends Subscriber
     /**
      * Save error event
      *
-     * @param  MessageEvent $event
+     * @param  ErrorEvent $event
      * @return void
      */
-    public function onFileError(MessageEvent $event)
+    public function onFileError(ErrorEvent $event)
     {
         $this->errors[] = $event;
     }

--- a/src/Subscriber/ExitCodeCatcher.php
+++ b/src/Subscriber/ExitCodeCatcher.php
@@ -3,7 +3,7 @@
 namespace Psecio\Parse\Subscriber;
 
 use Psecio\Parse\Event\IssueEvent;
-use Psecio\Parse\Event\MessageEvent;
+use Psecio\Parse\Event\ErrorEvent;
 
 /**
  * Capture the exit status code of a scan
@@ -39,10 +39,10 @@ class ExitCodeCatcher extends Subscriber
     /**
      * Set exit code 1 on file error
      *
-     * @param  MessageEvent $event
+     * @param  ErrorEvent $event
      * @return void
      */
-    public function onFileError(MessageEvent $event)
+    public function onFileError(ErrorEvent $event)
     {
         $this->exitCode = 1;
     }

--- a/src/Subscriber/OutputTrait.php
+++ b/src/Subscriber/OutputTrait.php
@@ -27,7 +27,6 @@ trait OutputTrait
     /**
      * Write to console
      *
-     * @param  string $format sprintf format string
      * @param  mixed  ...$arg Any number of sprintf arguments
      * @return void
      */

--- a/src/Subscriber/Subscriber.php
+++ b/src/Subscriber/Subscriber.php
@@ -6,6 +6,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Psecio\Parse\Event\Events;
 use Psecio\Parse\Event\FileEvent;
 use Psecio\Parse\Event\IssueEvent;
+use Psecio\Parse\Event\ErrorEvent;
 use Psecio\Parse\Event\MessageEvent;
 
 /**
@@ -83,10 +84,10 @@ class Subscriber implements EventSubscriberInterface, Events
     /**
      * Empty on file error method
      *
-     * @param  MessageEvent $event
+     * @param  ErrorEvent $event
      * @return void
      */
-    public function onFileError(MessageEvent $event)
+    public function onFileError(ErrorEvent $event)
     {
     }
 

--- a/src/Subscriber/Xml.php
+++ b/src/Subscriber/Xml.php
@@ -5,7 +5,7 @@ namespace Psecio\Parse\Subscriber;
 use Symfony\Component\Console\Output\OutputInterface;
 use XMLWriter;
 use Psecio\Parse\Event\IssueEvent;
-use Psecio\Parse\Event\MessageEvent;
+use Psecio\Parse\Event\ErrorEvent;
 
 /**
  * Xml generating event subscriber
@@ -70,10 +70,10 @@ class Xml extends Subscriber
     /**
      * Write error to document
      *
-     * @param  MessageEvent $event
+     * @param  ErrorEvent $event
      * @return void
      */
-    public function onFileError(MessageEvent $event)
+    public function onFileError(ErrorEvent $event)
     {
         $this->xmlWriter->startElement('error');
         $this->xmlWriter->writeElement('description', $event->getMessage());

--- a/tests/Event/ErrorEventTest.php
+++ b/tests/Event/ErrorEventTest.php
@@ -4,13 +4,13 @@ namespace Psecio\Parse\Event;
 
 use Mockery as m;
 
-class MessageEventTest extends \PHPUnit_Framework_TestCase
+class ErrorEventTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetMessage()
     {
         $this->assertSame(
             'my message',
-            (new MessageEvent('my message'))->getMessage()
+            (new ErrorEvent('my message', m::mock('\Psecio\Parse\File')))->getMessage()
         );
     }
 }

--- a/tests/RuleFactoryTest.php
+++ b/tests/RuleFactoryTest.php
@@ -24,7 +24,7 @@ class RuleFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testIncludeFilter()
     {
-        $rules = (new RuleFactory(['EvalFunction']))->createRuleCollection();
+        $rules = (new RuleFactory(['evalfunction']))->createRuleCollection();
 
         $this->assertTrue(
             $rules->has('EvalFunction'),
@@ -39,7 +39,7 @@ class RuleFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testExcludeFilter()
     {
-        $rules = (new RuleFactory([], ['EvalFunction']))->createRuleCollection();
+        $rules = (new RuleFactory([], ['evalfunction']))->createRuleCollection();
 
         $this->assertFalse(
             $rules->has('EvalFunction'),

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -82,7 +82,7 @@ class ScannerTest extends \PHPUnit_Framework_TestCase
         );
         $dispatcher->shouldReceive('dispatch')->ordered()->once()->with(
             Scanner::FILE_ERROR,
-            m::type('\Psecio\Parse\Event\MessageEvent')
+            m::type('\Psecio\Parse\Event\ErrorEvent')
         );
         $dispatcher->shouldReceive('dispatch')->ordered()->once()->with(Scanner::FILE_CLOSE);
         $dispatcher->shouldReceive('dispatch')->ordered()->once()->with(Scanner::SCAN_COMPLETE);

--- a/tests/Subscriber/ConsoleDotsTest.php
+++ b/tests/Subscriber/ConsoleDotsTest.php
@@ -28,7 +28,7 @@ class ConsoleDotsTest extends \PHPUnit_Framework_TestCase
         // Writes an E as an error occurs
         // Also triggers a new line as the line witdth is set to 2
         $console->onFileOpen(m::mock('\Psecio\Parse\Event\FileEvent'));
-        $console->onFileError(m::mock('\Psecio\Parse\Event\MessageEvent'));
+        $console->onFileError(m::mock('\Psecio\Parse\Event\ErrorEvent'));
         $console->onFileClose();
 
         // Writes an I as an issue occurs

--- a/tests/Subscriber/ConsoleLinesTest.php
+++ b/tests/Subscriber/ConsoleLinesTest.php
@@ -22,9 +22,9 @@ class ConsoleLinesTest extends \PHPUnit_Framework_TestCase
         $fileEvent->shouldReceive('getFile->getPath')->andReturn('/path/to/file');
 
         // Data for [ERROR] line
-        $messageEvent = m::mock('\Psecio\Parse\Event\MessageEvent');
-        $messageEvent->shouldReceive('getMessage')->andReturn('message');
-        $messageEvent->shouldReceive('getFile->getPath')->andReturn('/path/to/file');
+        $errorEvent = m::mock('\Psecio\Parse\Event\ErrorEvent');
+        $errorEvent->shouldReceive('getMessage')->andReturn('message');
+        $errorEvent->shouldReceive('getFile->getPath')->andReturn('/path/to/file');
 
         // Data for [ISSUE] line
         $issueEvent = m::mock('\Psecio\Parse\Event\IssueEvent');
@@ -42,7 +42,7 @@ class ConsoleLinesTest extends \PHPUnit_Framework_TestCase
 
         // Writes [PARSE] and [ERROR] lines
         $console->onFileOpen($fileEvent);
-        $console->onFileError($messageEvent);
+        $console->onFileError($errorEvent);
         $console->onFileClose();
 
         // Writes [PARSE] and [ISSUE] lines

--- a/tests/Subscriber/ConsoleReportTest.php
+++ b/tests/Subscriber/ConsoleReportTest.php
@@ -51,11 +51,11 @@ For more information execute 'psecio-parse rules rulename'
 
         $report->onScanStart();
 
-        $messageEvent = m::mock('\Psecio\Parse\Event\MessageEvent');
-        $messageEvent->shouldReceive('getMessage')->once()->andReturn('error description');
-        $messageEvent->shouldReceive('getFile->getPath')->once()->andReturn('/error/path');
+        $errorEvent = m::mock('\Psecio\Parse\Event\ErrorEvent');
+        $errorEvent->shouldReceive('getMessage')->once()->andReturn('error description');
+        $errorEvent->shouldReceive('getFile->getPath')->once()->andReturn('/error/path');
 
-        $report->onFileError($messageEvent);
+        $report->onFileError($errorEvent);
 
         $file = m::mock('\Psecio\Parse\File');
         $file->shouldReceive('getPath')->once()->andReturn('/issue/path');

--- a/tests/Subscriber/ExitCodeCatcherTest.php
+++ b/tests/Subscriber/ExitCodeCatcherTest.php
@@ -24,7 +24,7 @@ class ExitCodeCatcherTest extends \PHPUnit_Framework_TestCase
     public function testErrorcodeOnError()
     {
         $exitCode = new ExitCodeCatcher;
-        $exitCode->onFileError(m::mock('\Psecio\Parse\Event\MessageEvent'));
+        $exitCode->onFileError(m::mock('\Psecio\Parse\Event\ErrorEvent'));
         $this->assertSame(1, $exitCode->getExitCode());
     }
 }

--- a/tests/Subscriber/SubscriberTest.php
+++ b/tests/Subscriber/SubscriberTest.php
@@ -22,7 +22,7 @@ class SubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($subscriber->onFileOpen(m::mock('\Psecio\Parse\Event\FileEvent')));
         $this->assertNull($subscriber->onFileClose());
         $this->assertNull($subscriber->onFileIssue(m::mock('\Psecio\Parse\Event\IssueEvent')));
-        $this->assertNull($subscriber->onFileError(m::mock('\Psecio\Parse\Event\MessageEvent')));
+        $this->assertNull($subscriber->onFileError(m::mock('\Psecio\Parse\Event\ErrorEvent')));
         $this->assertNull($subscriber->onDebug(m::mock('\Psecio\Parse\Event\MessageEvent')));
     }
 }

--- a/tests/Subscriber/XmlTest.php
+++ b/tests/Subscriber/XmlTest.php
@@ -35,11 +35,11 @@ class XmlTest extends \PHPUnit_Framework_TestCase
 
         $xml->onScanStart();
 
-        $messageEvent = m::mock('\Psecio\Parse\Event\MessageEvent');
-        $messageEvent->shouldReceive('getMessage')->once()->andReturn('error description');
-        $messageEvent->shouldReceive('getFile->getPath')->once()->andReturn('/error/path');
+        $errorEvent = m::mock('\Psecio\Parse\Event\ErrorEvent');
+        $errorEvent->shouldReceive('getMessage')->once()->andReturn('error description');
+        $errorEvent->shouldReceive('getFile->getPath')->once()->andReturn('/error/path');
 
-        $xml->onFileError($messageEvent);
+        $xml->onFileError($errorEvent);
 
         $file = m::mock('\Psecio\Parse\File');
         $file->shouldReceive('getPath')->once()->andReturn('/issue/path');


### PR DESCRIPTION
The include and exclude options managing the ruleset are renamed whitelist and blacklist
A debug event is fired to display the rules used
A new event class, ErrorEvent, is created, to enable MessageEvent to handle non-file related cases.

Merging will close #55.