### PR TITLE
Fix issue when xdebug max nesting level is to low

### DIFF
--- a/bin/psecio-parse
+++ b/bin/psecio-parse
@@ -2,8 +2,8 @@
 <?php
 
 date_default_timezone_set('UTC');
-
 set_time_limit(0);
+ini_set('xdebug.max_nesting_level', 10000);
 
 (@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Psecio\Parse;
+
+/**
+ * @coversNothing
+ */
+class IntegrationTest extends \PHPUnit_Framework_TestCase
+{
+    const EXECUTABLE = "bin/psecio-parse";
+
+    /**
+     * This test concerns issue #58
+     * It will only fail if xdebug is enabled
+     */
+    public function testMaxNestingLevel()
+    {
+        $filename = sys_get_temp_dir() . '/' . uniqid('psecio-parse') . '.php';
+
+        file_put_contents(
+            $filename,
+            '<?php $a = "foo"' . implode('', array_fill(0, 200, '."bar"')) . ';'
+        );
+
+        pclose(popen(self::EXECUTABLE . " scan $filename", 'r'));
+        unlink($filename);
+    }
+}


### PR DESCRIPTION
Setting `xdebug.max_nesting_level` to a high value prevents parse from terminating with a fatal error when too complex statements are parsed. See test case.

Fixes #58 