### PR TITLE
Configuration file handling

### DIFF
--- a/src/Conf/Configuration.php
+++ b/src/Conf/Configuration.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+/**
+ * Scan configuration interface
+ */
+interface Configuration
+{
+    /**
+     * Get output format identifier
+     *
+     * @return string
+     */
+    public function getFormat();
+
+    /**
+     * Get list of paths to scan
+     *
+     * @return string[]
+     */
+    public function getPaths();
+
+    /**
+     * Get list of paths to ignore
+     *
+     * @return string[]
+     */
+    public function getIgnorePaths();
+
+    /**
+     * Get list of extensions to scan
+     *
+     * @return string[]
+     */
+    public function getExtensions();
+
+    /**
+     * Get list of whitelisted rules
+     *
+     * @return string[]
+     */
+    public function getRuleWhitelist();
+
+    /**
+     * Get list of blacklisted rules
+     *
+     * @return string[]
+     */
+    public function getRuleBlacklist();
+
+    /**
+     * Check if annotations should be disabled
+     *
+     * @return boolean
+     */
+    public function disableAnnotations();
+}

--- a/src/Conf/DefaultConf.php
+++ b/src/Conf/DefaultConf.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+/**
+ * Default configurations
+ */
+class DefaultConf implements Configuration
+{
+    public function getFormat()
+    {
+        return 'progress';
+    }
+
+    public function getPaths()
+    {
+        return [];
+    }
+
+    public function getIgnorePaths()
+    {
+        return [];
+    }
+
+    public function getExtensions()
+    {
+        return ['php', 'phps', 'phtml', 'php5'];
+    }
+
+    public function getRuleWhitelist()
+    {
+        return [];
+    }
+
+    public function getRuleBlacklist()
+    {
+        return [];
+    }
+
+    public function disableAnnotations()
+    {
+        return false;
+    }
+}

--- a/src/Conf/DualConf.php
+++ b/src/Conf/DualConf.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+/**
+ * Read configurations from dual sources
+ */
+class DualConf implements Configuration
+{
+    /**
+     * @var Configuration Primary configurations
+     */
+    private $primary;
+
+    /**
+     * @var Configuration Secondary configurations
+     */
+    private $secondary;
+
+    /**
+     * Load configurations
+     *
+     * Primary configurations take precedence if specified
+     *
+     * @param Configuration      $primary
+     * @param Configuration|null $secondary
+     */
+    public function __construct(Configuration $primary, Configuration $secondary = null)
+    {
+        $this->primary = $primary;
+        $this->secondary = $secondary ?: new DefaultConf;
+    }
+
+    /**
+     * Get output format identifier
+     *
+     * @return string
+     */
+    public function getFormat()
+    {
+        return strtolower($this->primary->getFormat() ?: $this->secondary->getFormat());
+    }
+
+    /**
+     * Get list of paths to scan
+     *
+     * @return string[]
+     */
+    public function getPaths()
+    {
+        return $this->primary->getPaths() ?: $this->secondary->getPaths();
+    }
+
+    /**
+     * Get list of paths to ignore
+     *
+     * @return string[]
+     */
+    public function getIgnorePaths()
+    {
+        return $this->primary->getIgnorePaths() ?: $this->secondary->getIgnorePaths();
+    }
+
+    /**
+     * Get list of extensions to scan
+     *
+     * @return string[]
+     */
+    public function getExtensions()
+    {
+        return $this->primary->getExtensions() ?: $this->secondary->getExtensions();
+    }
+
+    /**
+     * Get list of whitelisted rules
+     *
+     * @return string[]
+     */
+    public function getRuleWhitelist()
+    {
+        return $this->primary->getRuleWhitelist() ?: $this->secondary->getRuleWhitelist();
+    }
+
+    /**
+     * Get list of blacklisted rules
+     *
+     * @return string[]
+     */
+    public function getRuleBlacklist()
+    {
+        return $this->primary->getRuleBlacklist() ?: $this->secondary->getRuleBlacklist();
+    }
+
+    /**
+     * Check if annotations should be disabled
+     *
+     * @return boolean
+     */
+    public function disableAnnotations()
+    {
+        return $this->primary->disableAnnotations() || $this->secondary->disableAnnotations();
+    }
+}

--- a/src/Conf/UserConf.php
+++ b/src/Conf/UserConf.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * User specified command line configurations
+ */
+class UserConf implements Configuration
+{
+    /**
+     * @var InputInterface Input object
+     */
+    private $input;
+
+    /**
+     * Load user input
+     *
+     * @param InputInterface $input
+     */
+    public function __construct(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    public function getFormat()
+    {
+        return $this->input->getOption('format');
+    }
+
+    public function getPaths()
+    {
+        return $this->input->getArgument('path');
+    }
+
+    public function getIgnorePaths()
+    {
+        return $this->parseCsv($this->input->getOption('ignore-paths'));
+    }
+
+    public function getExtensions()
+    {
+        return $this->parseCsv($this->input->getOption('extensions'));
+    }
+
+    public function getRuleWhitelist()
+    {
+        return $this->parseCsv($this->input->getOption('whitelist-rules'));
+    }
+
+    public function getRuleBlacklist()
+    {
+        return $this->parseCsv($this->input->getOption('blacklist-rules'));
+    }
+
+    public function disableAnnotations()
+    {
+        return $this->input->getOption('disable-annotations');
+    }
+
+    /**
+     * Parse comma-separated values from string
+     *
+     * Using array_filter ensures that an empty array is returned when an empty
+     * string is parsed.
+     *
+     * @param  string $string
+     * @return array
+     */
+    private function parseCsv($string)
+    {
+        return array_filter(explode(',', $string));
+    }
+}

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -111,4 +111,19 @@ class RuleCollection implements Countable, IteratorAggregate
     {
         return $this->rules;
     }
+
+    /**
+     * Get a comma separated list of rules in collection
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return implode(',', array_map(
+            function (RuleInterface $rule) {
+                return $rule->getName();
+            },
+            $this->toArray()
+        ));
+    }
 }

--- a/tests/Command/ScanCommandTest.php
+++ b/tests/Command/ScanCommandTest.php
@@ -78,25 +78,6 @@ class ScanCommandTest extends \PHPUnit_Framework_TestCase
         $this->executeCommand(['--format' => 'this-format-does-not-exist']);
     }
 
-    public function testParseCsv()
-    {
-        $this->assertSame(
-            ['php', 'phps'],
-            (new ScanCommand)->parseCsv('php,phps'),
-            'parsing comma separated values should work'
-        );
-        $this->assertSame(
-            ['php', 'phps'],
-            array_values((new ScanCommand)->parseCsv('php,,phps')),
-            'multiple commas should be skipped while parsing csv'
-        );
-        $this->assertSame(
-            [],
-            (new ScanCommand)->parseCsv(''),
-            'parsing an empty string should return an empty array'
-        );
-    }
-
     private function executeCommand(array $input, array $options = array())
     {
         $application = new Application;

--- a/tests/Conf/DefaultConfTest.php
+++ b/tests/Conf/DefaultConfTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+class DefaultConfTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaults()
+    {
+        $conf = new DefaultConf;
+        $this->assertSame('progress', $conf->getFormat());
+        $this->assertSame([], $conf->getPaths());
+        $this->assertSame([], $conf->getIgnorePaths());
+        $this->assertSame(['php', 'phps', 'phtml', 'php5'], $conf->getExtensions());
+        $this->assertSame([], $conf->getRuleWhitelist());
+        $this->assertSame([], $conf->getRuleBlacklist());
+        $this->assertFalse($conf->disableAnnotations());
+    }
+}

--- a/tests/Conf/DualConfTest.php
+++ b/tests/Conf/DualConfTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+use Mockery as m;
+
+class DualConfTest extends \PHPUnit_Framework_TestCase
+{
+    public function cascadeProvider()
+    {
+        return [
+            ['getFormat',          'first',   'second',   'first'   ],
+            ['getFormat',          '',        'second',   'second'  ],
+            ['getPaths',           ['first'], ['second'], ['first'] ],
+            ['getPaths',           [],        ['second'], ['second']],
+            ['getIgnorePaths',     ['first'], ['second'], ['first'] ],
+            ['getIgnorePaths',     [],        ['second'], ['second']],
+            ['getExtensions',      ['first'], ['second'], ['first'] ],
+            ['getExtensions',      [],        ['second'], ['second']],
+            ['getRuleWhitelist',   ['first'], ['second'], ['first'] ],
+            ['getRuleWhitelist',   [],        ['second'], ['second']],
+            ['getRuleBlacklist',   ['first'], ['second'], ['first'] ],
+            ['getRuleBlacklist',   [],        ['second'], ['second']],
+            ['disableAnnotations', false,     false,      false     ],
+            ['disableAnnotations', true,      false,      true      ],
+            ['disableAnnotations', false,     true,       true      ],
+        ];
+    }
+
+    /**
+     * @dataProvider cascadeProvider
+     */
+    public function testCascade($method, $first, $second, $expected)
+    {
+        $conf = new DualConf(
+            m::mock('Psecio\Parse\Conf\Configuration')->shouldReceive($method)->andReturn($first)->mock(),
+            m::mock('Psecio\Parse\Conf\Configuration')->shouldReceive($method)->andReturn($second)->mock()
+        );
+        $this->assertSame($expected, $conf->$method());
+    }
+}

--- a/tests/Conf/UserConfTest.php
+++ b/tests/Conf/UserConfTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Psecio\Parse\Conf;
+
+use Mockery as m;
+
+class UserConfTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFormat()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getOption')
+                ->with('format')
+                ->andReturn('foobar')
+                ->mock()
+        );
+        $this->assertSame('foobar', $conf->getFormat());
+    }
+
+    public function testPaths()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getArgument')
+                ->with('path')
+                ->andReturn(['path'])
+                ->mock()
+        );
+        $this->assertSame(['path'], $conf->getPaths());
+    }
+
+    public function testIgnorePaths()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getOption')
+                ->with('ignore-paths')
+                ->andReturn('path1,path2')
+                ->mock()
+        );
+        $this->assertSame(['path1', 'path2'], $conf->getIgnorePaths());
+    }
+
+    public function testExtensions()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getOption')
+                ->with('extensions')
+                ->andReturn('php,,phps')
+                ->mock()
+        );
+        $this->assertSame(['php', 'phps'], array_values($conf->getExtensions()));
+    }
+
+    public function testRuleWhitelist()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getOption')
+                ->with('whitelist-rules')
+                ->andReturn('')
+                ->mock()
+        );
+        $this->assertSame([], $conf->getRuleWhitelist());
+    }
+
+    public function testRuleBlacklist()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getOption')
+                ->with('blacklist-rules')
+                ->andReturn('rule')
+                ->mock()
+        );
+        $this->assertSame(['rule'], $conf->getRuleBlacklist());
+    }
+
+    public function testDisableAnnotations()
+    {
+        $conf = new UserConf(
+            m::mock('Symfony\Component\Console\Input\InputInterface')
+                ->shouldReceive('getOption')
+                ->with('disable-annotations')
+                ->andReturn(true)
+                ->mock()
+        );
+        $this->assertTrue($conf->disableAnnotations());
+    }
+}

--- a/tests/RuleCollectionTest.php
+++ b/tests/RuleCollectionTest.php
@@ -116,4 +116,14 @@ class RuleCollectionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('RuntimeException');
         (new RuleCollection)->remove('does-not-exist');
     }
+
+    public function testTostring()
+    {
+        $ruleA = m::mock('\Psecio\Parse\RuleInterface')->shouldReceive('getName')->andReturn('a')->mock();
+        $ruleB = m::mock('\Psecio\Parse\RuleInterface')->shouldReceive('getName')->andReturn('b')->mock();
+        $this->assertSame(
+            'a,b',
+            (string)(new RuleCollection([$ruleA, $ruleB]))
+        );
+    }
 }


### PR DESCRIPTION
First part of implementing #13.

Prepares for a configuration file by adding the ability of reading configs from multiple sources. Configuration handling is moved to the `Conf` namespace.

A concrete file implementation is missing.. Thoughts and suggestions are much welcomed!