### PR TITLE
Update IsFunctionCallTrait (IsFunctionTrait)

### DIFF
--- a/src/Rule/DisplayErrors.php
+++ b/src/Rule/DisplayErrors.php
@@ -4,7 +4,6 @@ namespace Psecio\Parse\Rule;
 
 use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
 
 /**
  * The "display_errors" setting should not be enabled manually
@@ -46,7 +45,7 @@ class DisplayErrors implements RuleInterface
         return true;
     }
 
-    private function readArgument(FuncCall $node, $index)
+    private function readArgument(Node $node, $index)
     {
         $arg = $this->getCalledFunctionArgument($node, $index);
         if ($this->isBoolLiteral($arg->value)) {

--- a/src/Rule/DisplayErrors.php
+++ b/src/Rule/DisplayErrors.php
@@ -4,7 +4,7 @@ namespace Psecio\Parse\Rule;
 
 use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
-use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
 
 /**
  * The "display_errors" setting should not be enabled manually
@@ -40,14 +40,15 @@ class DisplayErrors implements RuleInterface
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node, 'ini_set') && $this->readArg($node->args[0]) === 'display_errors') {
-            return in_array($this->readArg($node->args[1]), $this->allowed, true);
+        if ($this->isFunction($node, 'ini_set') && $this->readArgument($node, 0) === 'display_errors') {
+            return in_array($this->readArgument($node, 1), $this->allowed, true);
         }
         return true;
     }
 
-    private function readArg(Arg $arg)
+    private function readArgument(FuncCall $node, $index)
     {
+        $arg = $this->getCalledFunctionArgument($node, $index);
         if ($this->isBoolLiteral($arg->value)) {
             return (string)$arg->value->name;
         }

--- a/src/Rule/DisplayErrors.php
+++ b/src/Rule/DisplayErrors.php
@@ -30,7 +30,7 @@ use PhpParser\Node;
  */
 class DisplayErrors implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait, Helper\IsBoolLiteralTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait, Helper\IsBoolLiteralTrait;
 
     /**
      * @var array List of allowed display_errors settings
@@ -39,7 +39,7 @@ class DisplayErrors implements RuleInterface
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node, 'ini_set') && $this->readArgument($node, 0) === 'display_errors') {
+        if ($this->isFunctionCall($node, 'ini_set') && $this->readArgument($node, 0) === 'display_errors') {
             return in_array($this->readArgument($node, 1), $this->allowed, true);
         }
         return true;

--- a/src/Rule/EregFunctions.php
+++ b/src/Rule/EregFunctions.php
@@ -4,7 +4,6 @@ namespace Psecio\Parse\Rule;
 
 use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
 
 /**
  * Remove any use of ereg functions, deprecated as of PHP 5.3.0. Use preg_*
@@ -15,18 +14,13 @@ use PhpParser\Node\Expr\FuncCall;
 */
 class EregFunctions implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait;
-
-    private $functions = ['ereg', 'eregi', 'ereg_replace', 'eregi_replace'];
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        $nodeName = (is_object($node->name)) ? $node->name->parts[0] : $node->name;
-
-        if ($node instanceof FuncCall && in_array(strtolower($nodeName), $this->functions)) {
+        if ($this->isFunctionCall($node, ['ereg', 'eregi', 'ereg_replace', 'eregi_replace'])) {
             return false;
         }
-
         return true;
     }
 }

--- a/src/Rule/Extract.php
+++ b/src/Rule/Extract.php
@@ -17,23 +17,24 @@ use PhpParser\Node;
  */
 class Extract implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node, 'extract') === true) {
+        if ($this->isFunctionCall($node, 'extract')) {
             // Check to be sure it has two arguments
-            if (count($node->args) < 2) {
+            if ($this->countCalledFunctionArguments($node) < 2) {
                 return false;
             }
 
-            $name = (!isset($node->args[1]->value->name->parts[0]))
-                ? $node->args[1]->value->name : $node->args[1]->value->name->parts[0];
+            $arg = $this->getCalledFunctionArgument($node, 1);
+
+            $name = (isset($arg->value->name->parts[0]))
+                ? $arg->value->name->parts[0]
+                : $arg->value->name;
 
             // So we have two parameters...see if #2 is not equal to EXTR_OVERWRITE
-            if ($name === 'EXTR_OVERWRITE') {
-                return false;
-            }
+            return $name !== 'EXTR_OVERWRITE';
         }
         return true;
     }

--- a/src/Rule/HardcodedSensitiveValues.php
+++ b/src/Rule/HardcodedSensitiveValues.php
@@ -14,7 +14,7 @@ use PhpParser\Node;
  */
 class HardcodedSensitiveValues implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsExpressionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsExpressionTrait, Helper\IsFunctionCallTrait;
 
     private $sensitiveNames = [
         'username', 'user_name', 'password', 'user', 'pass', 'pwd', 'pswd',
@@ -43,9 +43,9 @@ class HardcodedSensitiveValues implements RuleInterface
             return [$node->name, $node->value];
         }
 
-        if ($this->isFunction($node, 'define')) {
-            $name = $node->args[0]->value->value;
-            $value = $node->args[1]->value;
+        if ($this->isFunctionCall($node, 'define')) {
+            $name = $this->getCalledFunctionArgument($node, 0)->value->value;
+            $value = $this->getCalledFunctionArgument($node, 1)->value;
 
             return [$name, $value];
         }

--- a/src/Rule/Helper/IsFunctionCallTrait.php
+++ b/src/Rule/Helper/IsFunctionCallTrait.php
@@ -10,24 +10,25 @@ use PhpParser\Node\Scalar\String;
 use LogicException;
 
 /**
- * Helper to evaluate if node is a function
+ * Helper to check if node is a function call
  */
-trait IsFunctionTrait
+trait IsFunctionCallTrait
 {
     /**
-     * Evaluate if $node is a function instance
+     * Check if $node is a function call
      *
      * Check for name too if provided
      *
-     * @param  Node   $node
-     * @param  string $name Function name
+     * @param  Node $node
+     * @param  string|string[] $names One or more function names to search for
      * @return boolean
      */
-    protected function isFunction(Node $node, $name = '')
+    protected function isFunctionCall(Node $node, $names = '')
     {
         if ($node instanceof FuncCall) {
-            if ($name) {
-                return $this->getCalledFunctionName($node) === $name;
+            if ($names) {
+                $names = array_map('strtolower', (array)$names);
+                return in_array(strtolower($this->getCalledFunctionName($node)), $names, true);
             }
             return true;
         }
@@ -69,5 +70,23 @@ trait IsFunctionTrait
             return $node->args[$index];
         }
         return new Arg(new String(''));
+    }
+
+    /**
+     * Count the arguments of called function
+     *
+     * @param  Node $node
+     * @return integer
+     * @throws LogicException If node is not an instance of FuncCall
+     */
+    protected function countCalledFunctionArguments(Node $node)
+    {
+        if (!$node instanceof FuncCall) {
+            throw new LogicException('Node must be an instance of FuncCall, found: ' . get_class($node));
+        }
+        if (is_array($node->args)) {
+            return count($node->args);
+        }
+        return 0;
     }
 }

--- a/src/Rule/Helper/IsFunctionTrait.php
+++ b/src/Rule/Helper/IsFunctionTrait.php
@@ -2,7 +2,11 @@
 
 namespace Psecio\Parse\Rule\Helper;
 
-use \PhpParser\Node;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Scalar\String;
 
 /**
  * Helper to evaluate if node is a function
@@ -14,28 +18,47 @@ trait IsFunctionTrait
      *
      * Check for name too if provided
      *
-     * @param  Node $node
+     * @param  Node   $node
      * @param  string $name Function name
      * @return boolean
      */
-    protected function isFunction(Node $node, $name = null)
+    protected function isFunction(Node $node, $name = '')
     {
-        $result = false;
-        if ($node instanceof \PhpParser\Node\Expr\FuncCall) {
-            $result = true;
-        }
-        if ($result === true && $name !== null) {
-            // This matches variables used as object names
-            if ($node->name instanceof \PhpParser\Node\Expr\ArrayDimFetch) {
-                return $result;
+        if ($node instanceof FuncCall) {
+            if ($name) {
+                return $this->getCalledFunctionName($node) === $name;
             }
-            $nodeName = ($node->name instanceof \PhpParser\Node\Expr\Variable)
-                ? $node->name->name : (string)$node->name;
+            return true;
+        }
+        return false;
+    }
 
-            if ($nodeName !== $name) {
-                $result = false;
-            }
+    /**
+     * Get name of called function
+     *
+     * @param  FuncCall $node
+     * @return string   Empty string if name could not be parsed
+     */
+    protected function getCalledFunctionName(FuncCall $node)
+    {
+        if ($node->name instanceof Name) {
+            return (string)$node->name;
         }
-        return $result;
+        return '';
+    }
+
+    /**
+     * Get argument of called function
+     *
+     * @param  FuncCall $node
+     * @param  integer  $index Index of argument to fetch
+     * @return Arg      If argument is not found an empty string is returned
+     */
+    protected function getCalledFunctionArgument(FuncCall $node, $index)
+    {
+        if (is_array($node->args) && array_key_exists($index, $node->args)) {
+            return $node->args[$index];
+        }
+        return new Arg(new String(''));
     }
 }

--- a/src/Rule/Helper/IsFunctionTrait.php
+++ b/src/Rule/Helper/IsFunctionTrait.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Scalar\String;
+use LogicException;
 
 /**
  * Helper to evaluate if node is a function
@@ -36,11 +37,15 @@ trait IsFunctionTrait
     /**
      * Get name of called function
      *
-     * @param  FuncCall $node
-     * @return string   Empty string if name could not be parsed
+     * @param  Node   $node
+     * @return string Empty string if name could not be parsed
+     * @throws LogicException If node is not an instance of FuncCall
      */
-    protected function getCalledFunctionName(FuncCall $node)
+    protected function getCalledFunctionName(Node $node)
     {
+        if (!$node instanceof FuncCall) {
+            throw new LogicException('Node must be an instance of FuncCall, found: ' . get_class($node));
+        }
         if ($node->name instanceof Name) {
             return (string)$node->name;
         }
@@ -50,12 +55,16 @@ trait IsFunctionTrait
     /**
      * Get argument of called function
      *
-     * @param  FuncCall $node
-     * @param  integer  $index Index of argument to fetch
-     * @return Arg      If argument is not found an empty string is returned
+     * @param  Node    $node
+     * @param  integer $index Index of argument to fetch
+     * @return Arg     If argument is not found an empty string is returned
+     * @throws LogicException If node is not an instance of FuncCall
      */
-    protected function getCalledFunctionArgument(FuncCall $node, $index)
+    protected function getCalledFunctionArgument(Node $node, $index)
     {
+        if (!$node instanceof FuncCall) {
+            throw new LogicException('Node must be an instance of FuncCall, found: ' . get_class($node));
+        }
         if (is_array($node->args) && array_key_exists($index, $node->args)) {
             return $node->args[$index];
         }

--- a/src/Rule/ImportRequestVariables.php
+++ b/src/Rule/ImportRequestVariables.php
@@ -14,10 +14,10 @@ use PhpParser\Node;
  */
 class ImportRequestVariables implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        return !$this->isFunction($node, 'import_request_variables');
+        return !$this->isFunctionCall($node, 'import_request_variables');
     }
 }

--- a/src/Rule/MysqlRealEscapeString.php
+++ b/src/Rule/MysqlRealEscapeString.php
@@ -14,10 +14,10 @@ use PhpParser\Node;
  */
 class MysqlRealEscapeString implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        return !($node instanceof \PhpParser\Node\Expr\FuncCall && $node->name == 'mysql_real_escape_string');
+        return !$this->isFunctionCall($node, 'mysql_real_escape_string');
     }
 }

--- a/src/Rule/OutputWithVariable.php
+++ b/src/Rule/OutputWithVariable.php
@@ -6,7 +6,7 @@ use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Stmt\Echo_;
-use PhpParser\Node\Stmt\Print_;
+use PhpParser\Node\Expr\Print_;
 
 /**
  * Avoid the use of an output method (echo, print, etc) directly with a variable

--- a/src/Rule/OutputWithVariable.php
+++ b/src/Rule/OutputWithVariable.php
@@ -7,7 +7,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Print_;
-use PhpParser\Node\Expr\FuncCall;
 
 /**
  * Avoid the use of an output method (echo, print, etc) directly with a variable
@@ -18,9 +17,7 @@ use PhpParser\Node\Expr\FuncCall;
  */
 class OutputWithVariable implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait;
-
-    private $outputFunctions = ['print_r', 'printf', 'vprintf', 'sprintf'];
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
@@ -32,8 +29,8 @@ class OutputWithVariable implements RuleInterface
         }
 
         // See if our other output functions use concat
-        if ($node instanceof FuncCall && in_array($node->name, $this->outputFunctions)) {
-            if (isset($node->args[0]) && $node->args[0]->value instanceof Concat) {
+        if ($this->isFunctionCall($node, ['print_r', 'printf', 'vprintf', 'sprintf'])) {
+            if ($this->getCalledFunctionArgument($node, 0)->value instanceof Concat) {
                 return false;
             }
         }

--- a/src/Rule/ParseStr.php
+++ b/src/Rule/ParseStr.php
@@ -14,10 +14,10 @@ use PhpParser\Node;
  */
 class ParseStr implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        return !$this->isFunction($node, 'mb_parse_str') && !$this->isFunction($node, 'parse_str');
+        return !$this->isFunctionCall($node, ['parse_str', 'mb_parse_str']);
     }
 }

--- a/src/Rule/PregReplaceWithEvalModifier.php
+++ b/src/Rule/PregReplaceWithEvalModifier.php
@@ -42,12 +42,12 @@ use PhpParser\Node;
  */
 class PregReplaceWithEvalModifier implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node, 'preg_replace')) {
-            if (preg_match("/e[a-zA-Z]*$/", $node->args[0]->value->value)) {
+        if ($this->isFunctionCall($node, 'preg_replace')) {
+            if (preg_match("/e[a-zA-Z]*$/", $this->getCalledFunctionArgument($node, 0)->value->value)) {
                 return false;
             }
         }

--- a/src/Rule/Readfile.php
+++ b/src/Rule/Readfile.php
@@ -14,12 +14,10 @@ use PhpParser\Node;
  */
 class Readfile implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        return !$this->isFunction($node, 'readfile')
-            && !$this->isFunction($node, 'readlink')
-            && !$this->isFunction($node, 'readgzfile');
+        return !$this->isFunctionCall($node, ['readfile', 'readlink', 'readgzfile']);
     }
 }

--- a/src/Rule/RunkitImport.php
+++ b/src/Rule/RunkitImport.php
@@ -14,10 +14,10 @@ use PhpParser\Node;
  */
 class RunkitImport implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        return !$this->isFunction($node, 'runkit_import');
+        return !$this->isFunctionCall($node, 'runkit_import');
     }
 }

--- a/src/Rule/SessionRegenerateId.php
+++ b/src/Rule/SessionRegenerateId.php
@@ -14,23 +14,13 @@ use PhpParser\Node;
  */
 class SessionRegenerateId implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait, Helper\IsBoolLiteralTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait, Helper\IsBoolLiteralTrait;
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node, 'session_regenerate_id') === true) {
-            // If the argument isn't even set...
-            if (count($node->args) < 1) {
-                return false;
-            }
-
-            // If it's set but it's set to false
-            $arg = $node->args[0];
-            if (!$this->isBoolLiteral($arg->value, true)) {
-                return false;
-            }
+        if ($this->isFunctionCall($node, 'session_regenerate_id')) {
+            return $this->isBoolLiteral($this->getCalledFunctionArgument($node, 0)->value, true);
         }
-
         return true;
     }
 }

--- a/src/Rule/SetHeaderWithInput.php
+++ b/src/Rule/SetHeaderWithInput.php
@@ -4,6 +4,7 @@ namespace Psecio\Parse\Rule;
 
 use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 
 /**
  * 'header()' calls should not use concatenation directly
@@ -14,12 +15,12 @@ use PhpParser\Node;
  */
 class SetHeaderWithInput implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait;
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node, 'header') === true) {
-            if ($node->args[0]->value instanceof \PhpParser\Node\Expr\BinaryOp\Concat) {
+        if ($this->isFunctionCall($node, 'header')) {
+            if ($this->getCalledFunctionArgument($node, 0)->value instanceof Concat) {
                 return false;
             }
         }

--- a/src/Rule/SystemFunctions.php
+++ b/src/Rule/SystemFunctions.php
@@ -16,8 +16,6 @@ class SystemFunctions implements RuleInterface
 {
     use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait, Helper\IsExpressionTrait;
 
-    private $functions = ['exec', 'passthru', 'system'];
-
     public function isValid(Node $node)
     {
         if ($this->isFunctionCall($node, ['exec', 'passthru', 'system'])) {

--- a/src/Rule/SystemFunctions.php
+++ b/src/Rule/SystemFunctions.php
@@ -14,17 +14,14 @@ use PhpParser\Node;
  */
 class SystemFunctions implements RuleInterface
 {
-    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionTrait, Helper\IsExpressionTrait;
+    use Helper\NameTrait, Helper\DocblockDescriptionTrait, Helper\IsFunctionCallTrait, Helper\IsExpressionTrait;
 
     private $functions = ['exec', 'passthru', 'system'];
 
     public function isValid(Node $node)
     {
-        if ($this->isFunction($node)) {
-            $name = (is_object($node->name)) ? $node->name->parts[0] : $node->name;
-            if (in_array(strtolower($name), $this->functions)) {
-                return false;
-            }
+        if ($this->isFunctionCall($node, ['exec', 'passthru', 'system'])) {
+            return false;
         }
 
         return !$this->isExpression($node, 'ShellExec');

--- a/src/Subscriber/ConsoleDebug.php
+++ b/src/Subscriber/ConsoleDebug.php
@@ -10,7 +10,7 @@ use Psecio\Parse\Event\MessageEvent;
 class ConsoleDebug extends ConsoleLines
 {
     /**
-     * @var integer Unix timestamp at scan start
+     * @var double Unix timestamp at scan start
      */
     private $startTime;
 

--- a/tests/Rule/DisplayErrorsTest.php
+++ b/tests/Rule/DisplayErrorsTest.php
@@ -7,18 +7,19 @@ class DisplayErrorsTest extends RuleTestCase
     public function parseSampleProvider()
     {
         return [
-            ["ini_set('display_errors', 0);", true],
-            ["ini_set('display_errors', '0');", true],
-            ["ini_set('display_errors', false);", true],
-            ["ini_set('display_errors', 'false');", true],
-            ["ini_set('display_errors', 'off');", true],
+            ["ini_set('display_errors', 0);",        true],
+            ["ini_set('display_errors', '0');",      true],
+            ["ini_set('display_errors', false);",    true],
+            ["ini_set('display_errors', 'false');",  true],
+            ["ini_set('display_errors', 'off');",    true],
             ["ini_set('display_errors', 'stderr');", true],
-            ["ini_set('something-else', 1);", true],
-            ["ini_set('display_errors', 1);", false],
-            ["ini_set('display_errors', '1');", false],
-            ["ini_set('display_errors', true);", false],
-            ["ini_set('display_errors', 'true');", false],
-            ["ini_set('display_errors', 'on');", false],
+            ["ini_set('something-else', 1);",        true],
+            ["ini_set('display_errors', 1);",        false],
+            ["ini_set('display_errors', '1');",      false],
+            ["ini_set('display_errors', true);",     false],
+            ["ini_set('display_errors', 'true');",   false],
+            ["ini_set('display_errors', 'on');",     false],
+            ["ini_set('display_errors');",           false],
         ];
     }
 

--- a/tests/Rule/SessionRegenerateIdTest.php
+++ b/tests/Rule/SessionRegenerateIdTest.php
@@ -7,13 +7,13 @@ class SessionRegenerateIdTest extends RuleTestCase
     public function parseSampleProvider()
     {
         return [
-            ['$x = 17;', true],
-            ['session_regenerate_id();', false],
-            ['session_regenerate_id(false);', false],
-            ['session_regenerate_id(true);', true],
-            ['session_regenerate_id(17);', false],
-            ['$x["a"]("blah");', false],
-            ['random_function();', true],
+            ['session_regenerate_id();',       false],
+            ['session_regenerate_id(false);',  false],
+            ['session_regenerate_id(17);',     false],
+            ['session_regenerate_id(true);',   true],
+            ['$session_regenerate_id();',      true],
+            ['$x["session_regenerate_id"]();', true],
+            ['random_function();',             true],
         ];
     }
 

--- a/tests/Rule/SystemFunctionsTest.php
+++ b/tests/Rule/SystemFunctionsTest.php
@@ -7,11 +7,12 @@ class SystemFunctionsTest extends RuleTestCase
     public function parseSampleProvider()
     {
         return [
-            ['exec();', false],
-            ['passthru();', false],
-            ['system();', false],
-            ['$x = `ls -al`;', false],
-            ['another_function();', true],
+            ['EXEC();',         false],
+            ['exec();',         false],
+            ['passthru();',     false],
+            ['system();',       false],
+            ['$x = `ls -al`;',  false],
+            ['another_func();', true],
         ];
     }
 


### PR DESCRIPTION
The scrutinizer tool finds a number of issues in parse. See https://scrutinizer-ci.com/g/hanneskod/parse/.

This pr targets the scrutinizr issues in `IsFunctionCallTrait` (renamed, formerly `IsFunctionTrait`). The `PhpParser` interface isn't always easy to work with... This adds some instance checks and makes `isFunctionCall()` more versatile.

One change requires extra comments:

I have removed the ability of `isFunctionCall()` to parse variable names and return true if the function call is from an array. Maybe I am missunderstanding something, but these checks seem mistaken to me.

```php
$session_regenerate_id();
```
should not cause an error, as we do not know the contents of the variable..