### PR TITLE
Check for missing name property in IsBoolLiteral

### DIFF
--- a/src/Rule/Helper/IsBoolLiteralTrait.php
+++ b/src/Rule/Helper/IsBoolLiteralTrait.php
@@ -20,7 +20,7 @@ trait IsBoolLiteralTrait
      */
     protected function isBoolLiteral(Node $node, $value = null)
     {
-        if ($node->name instanceof \PhpParser\Node\Name) {
+        if (isset($node->name) && $node->name instanceof \PhpParser\Node\Name) {
             $name = strtolower($node->name);
             if ($name === 'true' || $name === 'false') {
                 if ($value === true) {


### PR DESCRIPTION
The `IsBoolLiteral` trait checks that the `name` property of the
Node. In the current version of PhpParser, the `name` property *may* not
be present. So check for it first.