### PR TITLE
Update packages, code and test for running on PHP7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /vendor
 /composer.lock
-/bin/coveralls
-/bin/phpunit
-/bin/test-reporter
+/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: php
 
 php:
   - hhvm
+  - 7.0
   - 5.6
-  - 5.5
-  - 5.4
 
 install:
   - composer install --dev --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require":{
-        "php": ">=5.4",
-        "nikic/php-parser": "~1.0",
-        "symfony/console": "~2.5",
-        "symfony/event-dispatcher": "~2.4"
+        "php": ">=5.6",
+        "nikic/php-parser": "~2.0",
+        "symfony/console": "~3.0",
+        "symfony/event-dispatcher": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*",
+        "phpunit/phpunit": "5.1.*",
         "codeclimate/php-test-reporter": "dev-master",
         "mockery/mockery": "0.9.*",
         "akamon/mockery-callable-mock": "~1.0"
@@ -40,5 +40,8 @@
     "bin": [
         "bin/psecio-parse",
         "bin/parse"
-    ]
+    ],
+    "archive": {
+        "exclude": ["/examples", "/tests"]
+    }
 }

--- a/src/Rule/DisplayErrors.php
+++ b/src/Rule/DisplayErrors.php
@@ -2,6 +2,7 @@
 
 namespace Psecio\Parse\Rule;
 
+use PhpParser\Node\Expr;
 use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
 

--- a/src/Rule/HardcodedSensitiveValues.php
+++ b/src/Rule/HardcodedSensitiveValues.php
@@ -2,6 +2,10 @@
 
 namespace Psecio\Parse\Rule;
 
+use PhpParser\Node\Const_;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Scalar\String_;
 use Psecio\Parse\RuleInterface;
 use PhpParser\Node;
 
@@ -30,7 +34,7 @@ class HardcodedSensitiveValues implements RuleInterface
 
         // Fail on straight $var = 'value', where $var is in $sensitiveNames
         return !($this->isSensitiveName($name) &&
-                 $value instanceof \PhpParser\Node\Scalar\String);
+                 $value instanceof String_);
     }
 
     protected function getNameAndValue($node)
@@ -39,7 +43,7 @@ class HardcodedSensitiveValues implements RuleInterface
             return [$node->var->name, $node->expr];
         }
 
-        if ($node instanceof \PhpParser\Node\Const_) {
+        if ($node instanceof Const_) {
             return [$node->name, $node->value];
         }
 

--- a/src/Rule/Helper/IsFunctionCallTrait.php
+++ b/src/Rule/Helper/IsFunctionCallTrait.php
@@ -6,7 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Scalar\String;
+use PhpParser\Node\Scalar\String_;
 use LogicException;
 
 /**
@@ -69,7 +69,7 @@ trait IsFunctionCallTrait
         if (is_array($node->args) && array_key_exists($index, $node->args)) {
             return $node->args[$index];
         }
-        return new Arg(new String(''));
+        return new Arg(new String_(''));
     }
 
     /**

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -2,11 +2,10 @@
 
 namespace Psecio\Parse;
 
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use PhpParser\Parser;
-use PhpParser\Lexer\Emulative as Lexer;
-use PhpParser\NodeTraverser;
 use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Iterates over and validates files, dispatching events
@@ -49,7 +48,7 @@ class Scanner implements Event\Events
     ) {
         $this->dispatcher = $dispatcher;
         $this->visitor = $visitor;
-        $this->parser = $parser ?: new Parser(new Lexer);
+        $this->parser = $parser ?: (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         $this->traverser = $traverser ?: new NodeTraverser;
         $this->visitor->onNodeFailure([$this, 'onNodeFailure']);
         $this->traverser->addVisitor($this->visitor);

--- a/tests/FileIteratorTest.php
+++ b/tests/FileIteratorTest.php
@@ -2,6 +2,8 @@
 
 namespace Psecio\Parse;
 
+use DirectoryIterator;
+
 /**
  * @covers \Psecio\Parse\FileIterator
  */

--- a/tests/Rule/RuleTestCase.php
+++ b/tests/Rule/RuleTestCase.php
@@ -2,9 +2,9 @@
 
 namespace Psecio\Parse\Rule;
 
-use Psecio\Parse\RuleInterface;
 use PhpParser\Parser;
-use PhpParser\Lexer\Emulative as Lexer;
+use Psecio\Parse\RuleInterface;
+use PhpParser\ParserFactory;
 use PhpParser\NodeTraverser;
 
 /**
@@ -22,7 +22,7 @@ abstract class RuleTestCase extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->parser = new Parser(new Lexer);
+        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
     }
 
     /**
@@ -91,7 +91,7 @@ abstract class RuleTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Assert that running $test against $code results in $expected
      *
-     * Note taht $message does not replace the message from the assertion,
+     * Note that $message does not replace the message from the assertion,
      * only augments it.
      *
      * @param string  $code      The PHP code to parse and evaulate

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -37,7 +37,7 @@ class ScannerTest extends \PHPUnit_Framework_TestCase
         $scanner = new Scanner(
             $dispatcher,
             m::mock('\Psecio\Parse\CallbackVisitor')->shouldReceive('onNodeFailure', 'setFile')->mock(),
-            m::mock('\PhpParser\Parser')->shouldReceive('parse')->andReturn([])->mock(),
+            m::mock('alias:Psecio\Parse\Parser')->shouldReceive('parse')->andReturn([])->mock(),
             m::mock('\PhpParser\NodeTraverser')->shouldReceive('traverse', 'addVisitor')->mock()
         );
 
@@ -60,7 +60,7 @@ class ScannerTest extends \PHPUnit_Framework_TestCase
         $scanner = new Scanner(
             $dispatcher,
             m::mock('\Psecio\Parse\CallbackVisitor')->shouldReceive('onNodeFailure', 'setFile')->mock(),
-            m::mock('\PhpParser\Parser')->shouldReceive('parse')->andThrow(new \PhpParser\Error(''))->mock(),
+            m::mock('alias:Psecio\Parse\Parser')->shouldReceive('parse')->andThrow(new \PhpParser\Error(''))->mock(),
             m::mock('\PhpParser\NodeTraverser')->shouldReceive('addVisitor')->mock()
         );
 


### PR DESCRIPTION
Hi, 

This pull request adds support for PHP7. It upgrades a number of support packages (which in turn removes support for PHP5.4 and 5.5), and fixes issues with the newer version of the PHP Parser package.

I have updated the tests and they are passing on PHP 5.6, HHVM and PHP 7.0 [![Build Status](https://travis-ci.org/randompixel/parse.svg?branch=php7.0-fixes)](https://travis-ci.org/randompixel/parse)

I have run the program against itself and a large project that I work on, and things appear to still work.