### PR TITLE
The "parse_str" with 2 arguments isn't a security risk

### DIFF
--- a/src/Rule/ParseStr.php
+++ b/src/Rule/ParseStr.php
@@ -18,6 +18,10 @@ class ParseStr implements RuleInterface
 
     public function isValid(Node $node)
     {
-        return !$this->isFunctionCall($node, ['parse_str', 'mb_parse_str']);
+        if (!$this->isFunctionCall($node, ['parse_str', 'mb_parse_str'])) {
+            return true;
+        }
+
+        return $this->countCalledFunctionArguments($node) > 1;
     }
 }

--- a/tests/Rule/ParseStrTest.php
+++ b/tests/Rule/ParseStrTest.php
@@ -7,7 +7,12 @@ class ParseStrTest extends RuleTestCase
     public function parseSampleProvider()
     {
         return [
-            ['parse_str();', false],
+            ['parse_str(\'text\');', false],
+            ['parse_str("text");', false],
+            ['parse_str($var1);', false],
+            ['parse_str(\'text\', $var2);', true],
+            ['parse_str("text", $var2);', true],
+            ['parse_str($var1, $var2);', true],
             ['mb_parse_str();', false],
             ['another_function();', true],
         ];


### PR DESCRIPTION
Closes #75