### PR TITLE
Update Symfony components to remove conflict with PHPSpec 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require":{
         "php": ">=5.4",
         "nikic/php-parser": "^1.0|^2.0",
-        "symfony/console": "~2.5",
-        "symfony/event-dispatcher": "~2.4"
+        "symfony/console": "~2.5|~3.1",
+        "symfony/event-dispatcher": "~2.4|~3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",


### PR DESCRIPTION
If you have Symfony 3.1 components, such as console, installing Parse 0.7 will either downgrade those components to 2.8 or conflict.

This pull request gives the option of using the Symfony 3.1 console components where appropriate. 

Tested a number of composer related scenarios and it seems ok. Tests still parse. Application still works.