### PR TITLE
Simplified and updated dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - hhvm
   - 7.0
@@ -8,7 +10,7 @@ php:
   - 5.4
 
 install:
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 script:
   - bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     ],
     "require":{
         "php": ">=5.4",
-        "nikic/php-parser": "^1.0|^2.0",
-        "symfony/console": "~2.5|~3.1",
-        "symfony/event-dispatcher": "~2.4|~3.1"
+        "nikic/php-parser": "^2.0",
+        "symfony/console": "2.5 - 3.2",
+        "symfony/event-dispatcher": "2.4 - 3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*",
+        "phpunit/phpunit": "^4.2",
         "codeclimate/php-test-reporter": "dev-master",
-        "mockery/mockery": "0.9.*",
-        "akamon/mockery-callable-mock": "~1.0"
+        "mockery/mockery": "^0.9",
+        "akamon/mockery-callable-mock": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I know in #87 you expressed some hesitation about using newer versions of dependencies, so allow me to explain what I've done.

- ~~My first commit just removed the old version numbers where a newer one was already given as an option.~~
- ~~You may wonder why I updated the PHP version requirement from 5.4 to 5.5.9; that's because some of the deps already required a minimum of 5.5.9 (for the newer versions), plus there's no need to support anything older if it's already been EOL for some time.~~
- ~~Then in the next one, I updated php-parser and phpunit, ran the tests, and updated the code and tests to reflect the changes in php-parser ^3.0.~~
- ~~Before I changed anything in composer.json, I ran the tests and noticed one test failing. After updating the versions, the code, and the tests, the same test was still failing.~~
- ~~After making my updates, I did start having trouble with the integration test causing a fatal error. My dev environment did have xdebug enabled, but the error I was getting wasn't the one you documented. It seemed very odd to me, but I would be interested to see if it would still show up if xdebug were taken out of the picture.~~

If there's anything you're not comfortable with, let me know and I'll change it back.
~~Also, if you have any ideas on why the integration test might be failing, I'd love to hear them. I spent a while trying to track it down and I didn't find any reason for the particular object being `null` at that point. What's weirder: when I added a line of debugging code, it went away. Makes no sense at all.~~